### PR TITLE
Added InvokeAsync() usage.

### DIFF
--- a/src/Blazor.LoadingIndicator/ILoadingService.cs
+++ b/src/Blazor.LoadingIndicator/ILoadingService.cs
@@ -7,7 +7,7 @@ namespace Blazor.LoadingIndicator
     {
         Type DefaultTemplateType { get; set; }
         Task StartTaskAsync(Func<ITaskStatus, Task> action, string context = "", string maintext = null, string subtext = null);
-        void SubscribeToTaskProgressChanged(string context, Action<ITaskStatus> action);
-        void UnsubscribeFromTaskProgressChanged(string context, Action<ITaskStatus> action);
+        void SubscribeToTaskProgressChanged(string context, Func<ITaskStatus, Task> action);
+        void UnsubscribeFromTaskProgressChanged(string context, Func<ITaskStatus, Task> action);
     }
 }

--- a/src/Blazor.LoadingIndicator/Indicator.razor
+++ b/src/Blazor.LoadingIndicator/Indicator.razor
@@ -33,15 +33,15 @@ else if (CurrentTask != null && _loadingFragment != null)
 
     private RenderFragment _loadingFragment;
 
-    private Action<ITaskStatus> HandleTaskProgressChangedEvent => new Action<ITaskStatus>((ITaskStatus task) =>
+    private Func<ITaskStatus, Task> HandleTaskProgressChangedEvent => new Func<ITaskStatus, Task>(async (ITaskStatus task) =>
     {
         CurrentTask = task;
         if (_template != null)
         {
             _template.CurrentTask = task;
-            _template.CallStateHasChanged();
+            await _template.CallStateHasChanged();
         }
-        StateHasChanged();
+        await InvokeAsync(StateHasChanged);
     });
     
 

--- a/src/Blazor.LoadingIndicator/LoadingIndicatorTemplateBase.cs
+++ b/src/Blazor.LoadingIndicator/LoadingIndicatorTemplateBase.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace Blazor.LoadingIndicator
 {
@@ -9,6 +10,6 @@ namespace Blazor.LoadingIndicator
     {
         public ITaskStatus CurrentTask { protected get; set; }
 
-        public void CallStateHasChanged() => StateHasChanged();
+        public Task CallStateHasChanged() => InvokeAsync(StateHasChanged);
     }
 }

--- a/src/Blazor.LoadingIndicator/LoadingService.cs
+++ b/src/Blazor.LoadingIndicator/LoadingService.cs
@@ -11,7 +11,7 @@ namespace Blazor.LoadingIndicator
         private class TaskContext
         {
             public List<RunningTask> Tasks = new List<RunningTask>();
-            public event Action<ITaskStatus> Changed;
+            public event Func<ITaskStatus, Task> Changed;
 
             public void FireChanged()
             {
@@ -57,7 +57,7 @@ namespace Blazor.LoadingIndicator
             }
         }
 
-        public void SubscribeToTaskProgressChanged(string context, Action<ITaskStatus> action)
+        public void SubscribeToTaskProgressChanged(string context, Func<ITaskStatus, Task> action)
         {
             if (!_dict.TryGetValue(context, out TaskContext c))
             {
@@ -69,7 +69,7 @@ namespace Blazor.LoadingIndicator
             c.FireChanged();
         }
 
-        public void UnsubscribeFromTaskProgressChanged(string context, Action<ITaskStatus> action)
+        public void UnsubscribeFromTaskProgressChanged(string context, Func<ITaskStatus, Task> action)
         {
             if (_dict.TryGetValue(context, out TaskContext c))
             {


### PR DESCRIPTION
A crash occured when refreshing the application on a .net core 3.0 blazor server side app. I added this as a fix. Just means that any thread can handle updates as it always invokes the StateHasChanged() on the ui thread. The templates still work as expected.